### PR TITLE
Fix spaces in list of supported runtimes

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -40,7 +40,7 @@
           Kubeless Includes:
         %ul
           %li
-            Support for Python, Node.js, Ruby, .Net Core, and custom runtimes
+            Support for Python, Node.js, Ruby, PHP, and custom runtimes
           %li
             CLI compliant with AWS Lambda CLI
           %li

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -40,7 +40,7 @@
           Kubeless Includes:
         %ul
           %li
-            Support for Python ,Node.js,  Ruby, .Net Core, and custom runtimes
+            Support for Python, Node.js, Ruby, .Net Core, and custom runtimes
           %li
             CLI compliant with AWS Lambda CLI
           %li


### PR DESCRIPTION
Minor change that fixes the spaces on the website.

#### Screenshot

![image](https://user-images.githubusercontent.com/13085980/37105508-a46f5c5e-222f-11e8-84cf-e21d7172521c.png)
