### PR TITLE
Docs: Adds Triggers and CronJob pages

### DIFF
--- a/source/layouts/partials/_links.html.haml
+++ b/source/layouts/partials/_links.html.haml
@@ -15,11 +15,17 @@
         = link_to '/docs/kubeless-functions' do
             Function Characteristics
     %li.margin-v-small
+        = link_to '/docs/triggers' do
+            Triggers
+    %li.margin-v-small
         = link_to '/docs/pubsub-functions' do
             PubSub Mechanism
     %li.margin-v-small
         = link_to '/docs/http-triggers' do
             Expose and Secure Functions
+    %li.margin-v-small
+        = link_to '/docs/cronjob-triggers' do
+            Scheduling a function execution (CronJob)
     %li.margin-v-small
         = link_to '/docs/streaming-functions' do
             Data Stream Events


### PR DESCRIPTION
## ☕ Purpose

This PR adds 2 pages to our docs: `Triggers` and `CronJob Trigger`. The idea is to make more intuitive for users to understand how to use our triggers.

## 🧐 Checklist

- [x] Adds pages on layout

## 🔗 Related PRs

This PR requires the following PR to be applied first: [kubeless#1127](https://github.com/kubeless/kubeless/pull/1127)